### PR TITLE
edid: don't automatically generate edid profiles by default

### DIFF
--- a/src/xiccd.c
+++ b/src/xiccd.c
@@ -42,6 +42,7 @@ show_version (void)
 
 static struct {
 	const gchar	*display;
+	      gboolean	edid;
 } config;
 
 static GOptionEntry config_entries[] = {
@@ -50,6 +51,8 @@ static GOptionEntry config_entries[] = {
 		"Show version", NULL },
 	{ "display", 'd', 0, G_OPTION_ARG_STRING, &config.display,
 		"X server to contact", NULL },
+	{ "edid", 'e', 0, G_OPTION_ARG_NONE, &config.edid,
+		"Generate EDID profile", NULL },
 	{ NULL }
 };
 
@@ -324,7 +327,9 @@ randr_display_added_sig (RandrConn *conn, struct randr_display *disp, Daemon *da
 
 	g_debug ("added display: '%s'", disp->name);
 
-	create_profile_from_edid (daemon->stor, &disp->edid);
+	if (config.edid) {
+		create_profile_from_edid (daemon->stor, &disp->edid);
+	}
 
 	g_hash_table_insert (props, CD_DEVICE_PROPERTY_KIND,
 			     (gchar *) cd_device_kind_to_string (CD_DEVICE_KIND_DISPLAY));


### PR DESCRIPTION
given that some linux applications are color managed and others
aren't, an auto-assigned auto-generated edid profile will cause
extreme confusion for many users, as two of their applications
which used to display images identically "suddenly" show a
single image differently.

since the user didn't assign/activate the edid profile, there
is no obvious way for a regular user to detect or trace their
issue to xiccd (as many users will be unaware they're running
xiccd or using color management in general).

also keeping in mind that edid profiles never contain a vcgt,
the usefulness of such a profile is quite limited, therefore
it could be considered that auto-assigning auto-generated
profiles to be a bad (but sadly common) practice.

this commit introduces a --edid flag, to restore the old
but arguably broken behavior.