### PR TITLE
exit when X server is not available or cannot be connected

### DIFF
--- a/src/randr-conn-private.c
+++ b/src/randr-conn-private.c
@@ -321,6 +321,21 @@ poll_events (gint fd, GIOCondition condition, gpointer user_data)
 	return TRUE;
 }
 
+static gboolean
+disconnected_event (gint fd, GIOCondition condition, gpointer user_data)
+{
+	struct randr_conn *conn = (struct randr_conn *) user_data;
+	(void) fd;
+
+	if(condition == G_IO_HUP) {
+		g_signal_emit (conn->object,
+			       randr_signals[SIG_DISCONNECTED], 0);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 static inline void
 setup_events (struct randr_conn *conn)
 {
@@ -334,6 +349,7 @@ setup_events (struct randr_conn *conn)
 		XNextEvent (conn->dpy, &ev);
 	}
 	g_unix_fd_add (ConnectionNumber (conn->dpy), G_IO_IN, poll_events, conn);
+	g_unix_fd_add (ConnectionNumber (conn->dpy), G_IO_HUP, disconnected_event, conn);
 }
 
 void

--- a/src/randr-conn-private.h
+++ b/src/randr-conn-private.h
@@ -53,6 +53,7 @@ struct randr_display_priv {
 enum {
 	SIG_DISPLAY_ADDED,
 	SIG_DISPLAY_REMOVED,
+	SIG_DISCONNECTED,
 	N_SIG
 };
 

--- a/src/randr-conn.c
+++ b/src/randr-conn.c
@@ -106,6 +106,12 @@ randr_conn_class_init (RandrConnClass *klass)
 		NULL, NULL, NULL,
 		G_TYPE_NONE, 1, G_TYPE_POINTER);
 
+	randr_signals[SIG_DISCONNECTED] = g_signal_new ("disconnected",
+		G_TYPE_FROM_CLASS (obj_class), G_SIGNAL_RUN_LAST,
+		G_STRUCT_OFFSET (RandrConnClass, disconnected),
+		NULL, NULL, NULL,
+		G_TYPE_NONE, 0);
+
 	g_object_class_install_property (obj_class, PROP_DISPLAY,
 		g_param_spec_string ("display", NULL, "X Display", NULL,
 				     G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY)
@@ -117,6 +123,12 @@ RandrConn *
 randr_conn_new (const gchar *display)
 {
 	RandrConn *obj = RANDR_CONN (g_object_new (RANDR_TYPE_CONN, "display", display, NULL));
+
+	if (obj->priv->dpy == NULL) {
+		g_object_unref(obj);
+		return NULL;
+	}
+
 	return obj;
 }
 

--- a/src/randr-conn.h
+++ b/src/randr-conn.h
@@ -65,6 +65,7 @@ typedef struct _RandrConnClass {
 	GObjectClass parent;
 	void (*display_added) (RandrConn *conn, const struct randr_display *disp);
 	void (*display_removed) (RandrConn *conn, const struct randr_display *disp);
+	void (*disconnected) (RandrConn *conn);
 } RandrConnClass;
 
 

--- a/src/xiccd.c
+++ b/src/xiccd.c
@@ -403,6 +403,13 @@ randr_display_removed_sig (RandrConn *conn, struct randr_display *disp, Daemon *
 	g_object_unref (device);
 }
 
+static void
+randr_disconnected (RandrConn *conn, Daemon *daemon)
+{
+	(void) daemon;
+	exit(0);
+}
+
 
 static void
 cd_existing_devices_cb (GObject *src, GAsyncResult *res, gpointer user_data)
@@ -556,6 +563,9 @@ cd_connect_cb (GObject *src, GAsyncResult *res, gpointer user_data)
 	g_signal_connect (daemon->rcon, "display-removed",
 			  G_CALLBACK (randr_display_removed_sig), daemon);
 
+	g_signal_connect (daemon->rcon, "disconnected",
+			  G_CALLBACK (randr_disconnected), daemon);
+
 	g_signal_connect (daemon->stor, "added",
 			  G_CALLBACK (cd_icc_store_file_added_sig), daemon);
 
@@ -614,6 +624,12 @@ main (int argc, char *argv[])
 
 	daemon.loop = g_main_loop_new (NULL, FALSE);
 	daemon.rcon = randr_conn_new (config.display);
+
+	if (daemon.rcon == NULL) {
+		g_critical ("Cannot connect to X server. Exiting");
+		return 1;
+	}
+
 	daemon.cli = cd_client_new ();
 	daemon.stor = cd_icc_store_new ();
 


### PR DESCRIPTION
In the original version, xiccd won't stop when the session is closed.  I modified the source code and make it stop when the connection to the x server closed. 