### PR TITLE
fix error message

### DIFF
--- a/src/xiccd.c
+++ b/src/xiccd.c
@@ -214,7 +214,6 @@ out:
 
 	if (device)
 		g_object_unref (device);
-	g_object_unref (profile);
 }
 
 


### PR DESCRIPTION
removing an extra g_object_unref that caused an error message
"g_object_unref: assertion 'G_IS_OBJECT (object)' failed"

Fixes #19