### PR TITLE
randr: fix race condition

### DIFF
--- a/src/randr-conn-private.c
+++ b/src/randr-conn-private.c
@@ -385,13 +385,16 @@ setup_events (struct randr_conn *conn)
 				RRCrtcChangeNotifyMask |
 				RROutputChangeNotifyMask);
 	}
-	while (XPending (conn->dpy)) {
-		XEvent ev;
-		XNextEvent (conn->dpy, &ev);
-	}
 	GSource *src = randr_source_new (conn);
 	g_source_attach (src, NULL);
 	g_source_unref (src);
+}
+
+void
+randr_conn_private_start (struct randr_conn *conn)
+{
+	randr_conn_private_update (conn);
+	setup_events (conn);
 }
 
 void
@@ -425,8 +428,6 @@ randr_conn_private_init (struct randr_conn *conn, const gchar *disp_name)
 	/* RandR 1.2 calls it "EDID_DATA" but we don't support 1.2 */
 	conn->edid_atom = XInternAtom (conn->dpy, "EDID", False);
 	conn->type_atom = XInternAtom (conn->dpy, "ConnectorType", False);
-
-	setup_events (conn);
 
 	return;
 

--- a/src/randr-conn-private.h
+++ b/src/randr-conn-private.h
@@ -67,6 +67,7 @@ extern guint randr_signals[N_SIG];
 
 void randr_conn_private_init (struct randr_conn *conn, const gchar *disp_name);
 void randr_conn_private_finalize (struct randr_conn *conn);
+void randr_conn_private_start (struct randr_conn *conn);
 void randr_conn_private_update (struct randr_conn *conn);
 struct randr_display *randr_conn_private_find_display (struct randr_conn *conn,
 						       const gchar *key, guint offset);

--- a/src/randr-conn.c
+++ b/src/randr-conn.c
@@ -127,9 +127,9 @@ randr_conn_new (const gchar *display)
 }
 
 void
-randr_conn_update (RandrConn *conn)
+randr_conn_start (RandrConn *conn)
 {
-	randr_conn_private_update (conn->priv);
+	randr_conn_private_start (conn->priv);
 }
 
 struct randr_display *

--- a/src/randr-conn.h
+++ b/src/randr-conn.h
@@ -74,7 +74,7 @@ GType randr_conn_get_type (void);
 
 RandrConn *randr_conn_new (const gchar *display);
 
-void randr_conn_update (RandrConn *conn);
+void randr_conn_start (RandrConn *conn);
 
 struct randr_display *randr_conn_find_display (RandrConn *conn, const gchar *name);
 struct randr_display *randr_conn_find_display_edid (RandrConn *conn, const gchar *edid_cksum);

--- a/src/xiccd.c
+++ b/src/xiccd.c
@@ -607,7 +607,7 @@ cd_connect_cb (GObject *src, GAsyncResult *res, gpointer user_data)
 				cd_existing_profiles_cb,
 				daemon);
 
-	randr_conn_update (daemon->rcon);
+	randr_conn_start (daemon->rcon);
 }
 
 


### PR DESCRIPTION
If xiccd was set to be launched at startup, a race condition could
occur.
randr_conn_private_update could be called twice when the program was
initialized and X events were received at the same time, leading to
incoherent results.

This prevents the issue by starting to process X events after the data
has been initialized.